### PR TITLE
add ByteBufCodable interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
       <artifactId>maljson</artifactId>
       <version>0.1.1</version>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-buffer</artifactId>
+      <version>4.0.17.Final</version>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/src/main/java/com/addthis/codec/Codec.java
+++ b/src/main/java/com/addthis/codec/Codec.java
@@ -39,6 +39,8 @@ import com.google.common.collect.HashBiMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import io.netty.buffer.ByteBuf;
+
 public abstract class Codec {
 
     private static final Logger log = LoggerFactory.getLogger(Codec.class);
@@ -125,6 +127,17 @@ public abstract class Codec {
         public byte[] bytesEncode();
 
         public void bytesDecode(byte b[]);
+    }
+
+    /**
+     * for classes that want to handle their own direct serialization and prefer to not
+     * use and/or allocate byte arrays
+     */
+    public static interface ByteBufCodable extends Codable {
+
+        public void writeBytes(ByteBuf buf);
+
+        public void readBytes(ByteBuf buf);
     }
 
     @SuppressWarnings("serial")


### PR DESCRIPTION
this is intended to replace the usage of BytesCodable for most use
cases. It adds a netty4 ByteBuf dependency, which we could get around
somewhat by using jdk ByteBuffers but eh, ByteBufs are better, most
codec users will be depending on ByteBufs soon enough anyway, and it
may be useful for further codec features.
