### PR TITLE
fix npe for generic types

### DIFF
--- a/src/main/java/com/addthis/codec/Codec.java
+++ b/src/main/java/com/addthis/codec/Codec.java
@@ -407,6 +407,8 @@ public abstract class Codec {
                     list.add(t);
                 } else if (t instanceof ParameterizedType) {
                     list.add(((ParameterizedType) t).getRawType());
+                } else {
+                    list.add(null);
                 }
             }
         }


### PR DESCRIPTION
this only changes behavior that was previously greeted with a npe time
bomb, so I am guessing it will be okay.

as an aside, I am a little surprised we don't see encoding/ decoding
come up more frequently as performance hot spots...
