### PR TITLE
add ArraySugar annotation for auto magic chains

### DIFF
--- a/src/main/java/com/addthis/codec/CodableClassInfo.java
+++ b/src/main/java/com/addthis/codec/CodableClassInfo.java
@@ -46,6 +46,10 @@ public final class CodableClassInfo {
         return classMap;
     }
 
+    public Class<?> getArraySugar() {
+        return (classMap != null) ? classMap.getArraySugar() : null;
+    }
+
     public String getClassField() {
         return classMap != null ? classMap.getClassField() : "class";
     }


### PR DESCRIPTION
this lets categories set a handler for 'unexpected' array types
over their base type. ie. instead of 'thing: {type: a, field: 5}',
you may arbitrarily put in 'thing: [{type: a, field: 5}, ...]' as
long as your base type has a chain-like implementation is is
annotated correctly.

example job using this sugar:

```
type: map

source: [
    { empty.maxPackets: 1 }
    { empty.maxPackets: 2 }
    { empty.maxPackets: 3 }
    { empty.maxPackets: 4 }
]

map.filterOut: [
    { field { from: counter,  filter.count.format: "0000000" } }
    { field { from: DATE_YMD, filter.time-range { offsetDays=-1, now=true, format=YYMMdd }}}
]

output: [
    { tree.paths.root: [ { const.value: empty } ], tree.enableJmx: false }
    { file { 
        path: ["{{DATE_YMD}}", "/", "SANDWICH"]
        writer.flags: {}
        writer.factory: {}
    }}
]
```

Note that without this change, the source would have to be manually decorated with the
aggregate task data source type, the filter would have to explicitly define a bundle filter chain,
and the output would have to wrap them in a task data output chain. Those things are still
occurring, but because, in my local stack, those wrapper-like classes have the ArraySugar
annotation, it is automagically magical-ed.
